### PR TITLE
Win7 workaround

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,6 +19,8 @@ text eol=lf
 # Declare text files that will stay in LF (i.e. not expected to be used on Windows)
 *.sh eol=lf
 *.sfd text eol=lf
+*.py text eol=lf
+wscript text eol=lf
 
 # Declare all files that are truly binary and should not be modified.
 *.png binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -19,8 +19,6 @@ text eol=lf
 # Declare text files that will stay in LF (i.e. not expected to be used on Windows)
 *.sh eol=lf
 *.sfd text eol=lf
-*.py text eol=lf
-wscript text eol=lf
 
 # Declare all files that are truly binary and should not be modified.
 *.png binary

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 font-nokyung
 ============
 
-Open font for the New Tai Lue script. This font is still experimental and may change considerably in the future. In particular, note that the Bold face source is identical to the Regular, and so is not included in the release.
+Open font for the Dai Banna script. This font is still experimental and make change considerably in the future. In particular, note that the Bold face source is identical to the Regular, and so is not included in the release.
 
 For copyright and licensing - including any Reserved Font Names - see [OFL.txt](OFL.txt).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 font-nokyung
 ============
 
-Open font for the Dai Banna script. This font is still experimental and make change considerably in the future. In particular, note that the Bold face source is identical to the Regular, and so is not included in the release.
+Open font for the New Tai Lue script. This font is still experimental and may change considerably in the future. In particular, note that the Bold face source is identical to the Regular, and so is not included in the release.
 
 For copyright and licensing - including any Reserved Font Names - see [OFL.txt](OFL.txt).
 

--- a/source/Nokyung-B.ufo/glyphs/dottedC_ircle.glif
+++ b/source/Nokyung-B.ufo/glyphs/dottedC_ircle.glif
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="dottedCircle" format="1">
   <advance width="1532"/>
+  <unicode hex="25CC"/>
   <outline>
     <contour>
       <point x="1129" y="925" type="curve" smooth="yes"/>

--- a/source/Nokyung-B.ufo/glyphs/dottedC_ircle.glif
+++ b/source/Nokyung-B.ufo/glyphs/dottedC_ircle.glif
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="dottedCircle" format="1">
   <advance width="1532"/>
-  <unicode hex="25CC"/>
   <outline>
     <contour>
       <point x="1129" y="925" type="curve" smooth="yes"/>

--- a/source/Nokyung-R.ufo/glyphs/dottedC_ircle.glif
+++ b/source/Nokyung-R.ufo/glyphs/dottedC_ircle.glif
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="dottedCircle" format="1">
   <advance width="1532"/>
+  <unicode hex="25CC"/>
   <outline>
     <contour>
       <point x="1129" y="925" type="curve" smooth="yes"/>

--- a/source/Nokyung-R.ufo/glyphs/dottedC_ircle.glif
+++ b/source/Nokyung-R.ufo/glyphs/dottedC_ircle.glif
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="dottedCircle" format="1">
   <advance width="1532"/>
-  <unicode hex="25CC"/>
   <outline>
     <contour>
       <point x="1129" y="925" type="curve" smooth="yes"/>

--- a/wscript
+++ b/wscript
@@ -13,14 +13,14 @@ STANDARDS = 'standards'
 # set the font name, version, licensing and description
 APPNAME="Nokyung"
 FILENAMEBASE="Nokyung"
-VERSION="1.302"
-TTF_VERSION="1.302"
-COPYRIGHT="Copyright (c) 2008-2016, SIL International (http://www.sil.org)"
+VERSION="1.300"
+TTF_VERSION="1.300"
+COPYRIGHT="Copyright (c) 2008-2015, SIL International (http://www.sil.org)"
 LICENSE='OFL.txt'
 
-DESC_SHORT = "Unicode font for New Tai Lue"
+DESC_SHORT = "Unicode font for Dai Banna"
 DESC_LONG = """
-Nokyung is a Unicode font for the New Tai Lue script.
+Nokyung is a Unicode font for the Dai Banna script.
 Font sources are published in the repository and a smith open workflow is
 used for building, testing and releasing.
 """

--- a/wscript
+++ b/wscript
@@ -13,14 +13,14 @@ STANDARDS = 'standards'
 # set the font name, version, licensing and description
 APPNAME="Nokyung"
 FILENAMEBASE="Nokyung"
-VERSION="1.300"
-TTF_VERSION="1.300"
-COPYRIGHT="Copyright (c) 2008-2015, SIL International (http://www.sil.org)"
+VERSION="1.302"
+TTF_VERSION="1.302"
+COPYRIGHT="Copyright (c) 2008-2016, SIL International (http://www.sil.org)"
 LICENSE='OFL.txt'
 
-DESC_SHORT = "Unicode font for Dai Banna"
+DESC_SHORT = "Unicode font for New Tai Lue"
 DESC_LONG = """
-Nokyung is a Unicode font for the Dai Banna script.
+Nokyung is a Unicode font for the New Tai Lue script.
 Font sources are published in the repository and a smith open workflow is
 used for building, testing and releasing.
 """


### PR DESCRIPTION
disabled dotted circle
fixed typos in descriptions
set UNIX EOL for code
